### PR TITLE
Fix bug in VASP IO write when `spec_structure_key` defined

### DIFF
--- a/atomate/vasp/firetasks/write_inputs.py
+++ b/atomate/vasp/firetasks/write_inputs.py
@@ -80,7 +80,7 @@ class WriteVaspFromIOSet(FiretaskBase):
             fw_struct = fw_spec.get(spec_structure_key)
             dd = vis.as_dict()
             dd["structure"] = fw_struct
-            vis.from_dict(dd)
+            vis = vis.from_dict(dd)
 
         potcar_spec = self.get("potcar_spec", False)
         vis.write_input(".", potcar_spec=potcar_spec)


### PR DESCRIPTION
`WriteVaspFromIOSet` does not correctly update the `vis` when `spec_structure_key` is set. The PR fixes the bug so the user-provided spec key can be passed.

## Summary

<Short few sentences, and summary of the major changes in bullet 
points>

* Feature 1
* Feature 2
* Fix 1
* Fix 2

## TODO (if any)

<If this is a work-in-progress, write something about what else needs 
to be done>

* Feature 1 supports a, but not b.